### PR TITLE
add self to auto_name in Protein class such that the class method doesn't error

### DIFF
--- a/goose/backend/protein.py
+++ b/goose/backend/protein.py
@@ -151,7 +151,7 @@ class Protein:
 
         return properties_dict
 
-    def auto_name():
+    def auto_name(self):
         # generates an autoname based on the sequence properties
         random_name = '>'
         amino_acids = ['A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'Y']


### PR DESCRIPTION
## Description
super minor bugfix

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] fix random auto_name feature in protein class

## Status
- [x] Ready to go