### PR TITLE
Add weighted shuffle feature

### DIFF
--- a/goose/backend/variant_generation.py
+++ b/goose/backend/variant_generation.py
@@ -1078,7 +1078,7 @@ def gen_targeted_shuffle_variant(sequence, target_aas, attempts=10,
             positive : KR
 
     attempts : int
-        the number of times ot try to make the sequence
+        the number of times to try to make the sequence
 
     disorder_threshold : float
         the threshold value required for an amino acid
@@ -1086,7 +1086,7 @@ def gen_targeted_shuffle_variant(sequence, target_aas, attempts=10,
 
     strict_disorder : Bool
         whether or not to require all disorder values to be 
-        over threshold or if it si okay to use the values
+        over threshold or if it is okay to use the values
         from the input sequence
     '''
     # dict of classes that are possible to choose

--- a/goose/backend/variant_generation.py
+++ b/goose/backend/variant_generation.py
@@ -1149,6 +1149,114 @@ def gen_targeted_shuffle_variant(sequence, target_aas, attempts=10,
 
     # if it doesn't work, raise an error
     raise GooseFail('Unable to generate sequence.')
+    
+    
+def gen_weighted_shuffle_variant(sequence, target_aas, shuffle_weight, attempts=10, 
+    disorder_threshold=parameters.DISORDER_THRESHOLD, strict_disorder=False):
+    '''
+    function that will let you perform a weighted shuffle a sequence by 
+    specifying residues or classes of residues to shuffle and a weight that
+    corresponds to the degree of shuffling that you want to perform. 
+    The weight is a number between 0.0-1.0 and corresponds to the probability
+    of moving a residue during shuffling. If you specify target amino acids, only
+    those amino acids are included in the shuffling and weighting can still be 
+    applied to only those target amino acids.
+
+    parameters
+    ----------
+    sequence : str
+        the amino acid sequence as a string
+
+    target_aas : str or list
+        a list of amino acids to target for shuffling
+        or a class of amino acids to target for shuffling
+        Possible target classes:
+            charged : DEKR
+            polar : QNST
+            aromatic : FYW
+            aliphatic : IVLAM
+            negative: DE
+            positive : KR
+            
+    shuffle_weight : float
+        a weight between 0.0-1.0 representing the probability of 
+        moving a residue during shuffling
+
+    attempts : int
+        the number of times to try to make the sequence
+
+    disorder_threshold : float
+        the threshold value required for an amino acid
+        to be considered disordered
+
+    strict_disorder : Bool
+        whether or not to require all disorder values to be 
+        over threshold or if it is okay to use the values
+        from the input sequence
+    '''
+    # dict of classes that are possible to choose
+    classdict={'charged':['D', 'E', 'K', 'R'], 'polar':['Q', 'N', 'S', 'T'], 'aromatic':
+    ['F', 'W', 'Y'], 'aliphatic': ['I', 'V', 'L', 'A', 'M'], 'negative':['D', 'E'], 'positive':['K', 'R']}
+    
+    # possible amino acids
+    amino_acids = ['A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'Y']
+
+    # verify target aas
+    if type(target_aas)==str:
+        if target_aas in amino_acids:
+            raise GooseInputError('You only specified a single amino acid. This will not change your sequence because the amino acids will just change places with itself.')
+        elif target_aas in classdict.keys():
+            target_aas = classdict[target_aas]
+        else:
+            raise GooseInputError('The specified target_aas is not a valid amino acid or class of amino acids.')
+    elif type(target_aas)==list:
+        for i in target_aas:
+            if i not in amino_acids:
+                raise GooseInputError('The specified target_aas is not a valid amino acid.')
+    else:
+        raise GooseInputError('The specified target_aas must be type list or string.')
+
+    # get original sequence disorder
+    starting_disorder = meta.predict_disorder(sequence)    
+
+    # define probabilities of not relocating a residue and relocating a residue, respectively
+    shuffle_weights=[1-shuffle_weight, shuffle_weight]
+    
+    # get list of target amino acids from the sequence
+    target_aa_list = [aa for aa in sequence if aa in target_aas]
+
+    # attempt to build sequence
+    for attempt_num in range(0, attempts):
+        # perform weighted sample to determine residues to shuffle
+        target_mask = random.choices([False, True], weights=shuffle_weights, k=len(target_aa_list))
+        mask = [target_mask.pop(0) if aa in target_aas else False for aa in sequence]
+
+        # gather positions and identities of residues to shuffle
+        orig_scramble_positions = [i for i, val in enumerate(mask) if val == True]
+        orig_aas = [sequence[i] for i in orig_scramble_positions]
+
+        # perform Fisher-Yates shuffle only with target_aas marked for shuffling
+        for i in range(len(orig_aas) - 1, 0, -1):
+            remaining_reposition_sites = orig_scramble_positions[:i]
+            
+            # randomly select new position for relocation of the target aa
+            new_position = random.choice(remaining_reposition_sites)
+            new_position_index = remaining_reposition_sites.index(new_position)
+            
+            # swap positions with another target aa marked for shuffling
+            orig_aas[i], orig_aas[new_position_index] = orig_aas[new_position_index], orig_aas[i]
+
+        # build final seq. Uses shuffled residues at sites marked for repositioning. Otherwise, uses the original residue at that site
+        final_seq = ''.join( [orig_aas.pop(0) if i in orig_scramble_positions else aa for i, aa in enumerate(sequence)] )
+        
+        # check disorder
+        if sequence_variant_disorder(final_seq, starting_disorder, 
+            cutoff_val=disorder_threshold, strict=strict_disorder) == True:
+            # if passes the 'disorder test', return the seq
+            return final_seq
+
+    # if it doesn't work, raise an error
+    raise GooseFail('Unable to generate sequence.')
 
 
 def gen_excluded_shuffle_variant(sequence, exclude_aas, attempts=10, 

--- a/goose/create.py
+++ b/goose/create.py
@@ -8,7 +8,7 @@
 ##Handles the primary functions
 
 # if any new functions are added to create.py, you need to add them here.
-__all__ =  ['seq_fractions', 'sequence', 'seq_re', 'seq_rg', 'minimal_var', 'new_seq_constant_class_var', 'constant_properties_var', 'constant_class_var', 'hydro_class_var', 'constant_residue_var', 'region_shuffle_var', 'kappa_var', 'asymmetry_var', 'fcr_class_var', 'ncpr_class_var', 'all_props_class_var', 're_var', 'rg_var', 'alpha_helix', 'beta_strand', 'beta_sheet', 'seq_property_library', 'excluded_shuffle_var', 'targeted_shuffle_var']
+__all__ =  ['seq_fractions', 'sequence', 'seq_re', 'seq_rg', 'minimal_var', 'new_seq_constant_class_var', 'constant_properties_var', 'constant_class_var', 'hydro_class_var', 'constant_residue_var', 'region_shuffle_var', 'kappa_var', 'asymmetry_var', 'fcr_class_var', 'ncpr_class_var', 'all_props_class_var', 're_var', 'rg_var', 'alpha_helix', 'beta_strand', 'beta_sheet', 'seq_property_library', 'excluded_shuffle_var', 'targeted_shuffle_var', 'weighted_shuffle_var']
 
 import os
 import sys
@@ -44,6 +44,7 @@ from goose.backend.variant_generation import gen_fcr_class_variant as _gen_fcr_c
 from goose.backend.variant_generation import gen_ncpr_class_variant as _gen_ncpr_class_variant
 from goose.backend.variant_generation import gen_all_props_class_variant as _gen_all_props_class_variant
 from goose.backend.variant_generation import gen_targeted_shuffle_variant as _gen_targeted_shuffle_variant
+from goose.backend.variant_generation import gen_weighted_shuffle_variant as _gen_weighted_shuffle_variant
 from goose.backend.variant_generation import gen_excluded_shuffle_variant as _gen_excluded_shuffle_variant
 from goose.backend.variant_generation import gen_dimensions_variant as _gen_dimensions_variant
 
@@ -1278,6 +1279,74 @@ def targeted_shuffle_var(sequence, target_aas, attempts=10,
     # make sequence.
     try:
         final_sequence = _gen_targeted_shuffle_variant(sequence, target_aas, attempts=attempts, disorder_threshold=cutoff, strict_disorder=strict)
+    except:
+        raise goose_exceptions.GooseFail('Sorry! GOOSE was unable to generate the sequence. Please try again or try with a different input values or a different cutoff value.')
+    return final_sequence
+    
+def weighted_shuffle_var(sequence, target_aas, shuffle_weight=1.0, attempts=10,
+    cutoff=parameters.DISORDER_THRESHOLD, strict=False):
+    '''
+    User facing funcitonality to generate variants where
+    you can specify residues or classes of residues to shuffle 
+    along with a weight to dictate how severely to shuffle
+    the sequence.
+
+    parameters
+    ----------
+    sequence : str
+        The amino acid sequence as a string.
+
+    target_aas : str or list
+        A list of amino acids to shuffle
+        or a class of amino acids to shuffle
+        Possible target classes:
+        charged : DEKR
+        polar : QNST
+        aromatic : FYW
+        aliphatic : IVLAM
+        negative: DE
+        positive : KR
+
+        If a list is specified, format should be (for example): 
+        target_aas['K', 'W', 'R', 'Y']
+        
+    shuffle_weight : float
+        a weight between 0.0-1.0 representing the probability of 
+        moving a residue during shuffling
+
+    attempts : int
+        Specify the number of times to make the sequence. Default is 10. Greater numbers
+        of attempts increase the odds that a sequence will be generated but will increase
+        the duration of attempting to make the sequence. (Optional)
+
+    cutoff : float
+        the cutoff value for disorder between 0 and 1. 
+        Higher values have a higher likelihood of being disordered. (Optional)
+
+    strict : bool
+        Whether to use a strict disorder calculation. By default, variants are allowed
+        to have regions below the disorder threshold *for regions where the input sequence
+        is also below the threshold*. (Optional)
+    
+    Returns
+    -------
+    Returns the amino acid sequence as a string. 
+    '''
+
+    # make sure that the input sequence is all caps
+    sequence = sequence.upper()
+
+    # check length
+    _length_check(sequence)
+
+    if cutoff > 1 or cutoff < 0:
+        raise goose_exceptions.GooseInputError('cutoff value must be between 0 and 1 for disorder threshold')    
+    if len(sequence) < 6:
+        raise GooseInputError('Cannot have sequence with a length less than 6')
+
+    # make sequence.
+    try:
+        final_sequence = _gen_weighted_shuffle_variant(sequence, target_aas, shuffle_weight, attempts=attempts, disorder_threshold=cutoff, strict_disorder=strict)
     except:
         raise goose_exceptions.GooseFail('Sorry! GOOSE was unable to generate the sequence. Please try again or try with a different input values or a different cutoff value.')
     return final_sequence


### PR DESCRIPTION
## Description
This feature allows users to define a weight (probability) that each target_aa is included in the shuffling operation. This allows users to create partially shuffled sequence by controlling the severity of the shuffling applied to the sequence.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [ x ] None

## Questions
- [ x ] None

## Status
- [ x ] Ready to go